### PR TITLE
Uplift GitHub workflows to run on ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Test rapidpro2pg
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     env:
       INT_PG_HOST: postgres
       INT_PG_PORT: 5432


### PR DESCRIPTION
Updates the GitHub workflows so that they run on the latest `ubuntu-22.04` image.

https://github.com/medic/cht-core/issues/7741